### PR TITLE
Install ruby-dev package instead of ruby.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   with_items:
       - sqlite3
       - libsqlite3-dev
-      - ruby
+      - ruby-dev
       - rubygems
       
 - name: Install Mailcatcher


### PR DESCRIPTION
So, this was happening when running the role on a "vanilla" Ubuntu Saucy VM. 

``` no-highlight
<192.168.90.103> ESTABLISH CONNECTION FOR USER: vagrant
<192.168.90.103> REMOTE_MODULE command gem install mailcatcher
<192.168.90.103> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/home/diogo/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=
22', '-o', 'IdentityFile=/home/diogo/.vagrant.d/insecure_private_key', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,pu
blickey', '-o', 'PasswordAuthentication=no', '-o', 'User=vagrant', '-o', 'ConnectTimeout=10', '192.168.90.103', "/bin/sh -c 'mkdir -p /tmp/ansible-tmp-1393931040.65-15247293340451 && ch
mod a+rx /tmp/ansible-tmp-1393931040.65-15247293340451 && echo /tmp/ansible-tmp-1393931040.65-15247293340451'"]
<192.168.90.103> PUT /tmp/tmpfFiAnj TO /tmp/ansible-tmp-1393931040.65-15247293340451/command
<192.168.90.103> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/home/diogo/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=
22', '-o', 'IdentityFile=/home/diogo/.vagrant.d/insecure_private_key', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,pu
blickey', '-o', 'PasswordAuthentication=no', '-o', 'User=vagrant', '-o', 'ConnectTimeout=10', '192.168.90.103', "/bin/sh -c 'chmod a+r /tmp/ansible-tmp-1393931040.65-15247293340451/comm
and'"]
<192.168.90.103> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/home/diogo/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=
22', '-o', 'IdentityFile=/home/diogo/.vagrant.d/insecure_private_key', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,pu
blickey', '-o', 'PasswordAuthentication=no', '-o', 'User=vagrant', '-o', 'ConnectTimeout=10', '192.168.90.103', '/bin/sh -c \'sudo -k && sudo -H -S -p "[sudo via ansible, key=orspfrlvya
sjsexalxaihjlgbejyifkm] password: " -u root /bin/sh -c \'"\'"\'echo SUDO-SUCCESS-orspfrlvyasjsexalxaihjlgbejyifkm; /usr/bin/python /tmp/ansible-tmp-1393931040.65-15247293340451/command;
 rm -rf /tmp/ansible-tmp-1393931040.65-15247293340451/ >/dev/null 2>&1\'"\'"\'\'']
<192.168.90.103> EXEC ['ssh', '-C', '-tt', '-vvv', '-o', 'ControlMaster=auto', '-o', 'ControlPersist=60s', '-o', 'ControlPath=/home/diogo/.ansible/cp/ansible-ssh-%h-%p-%r', '-o', 'Port=
22', '-o', 'IdentityFile=/home/diogo/.vagrant.d/insecure_private_key', '-o', 'KbdInteractiveAuthentication=no', '-o', 'PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,pu
blickey', '-o', 'PasswordAuthentication=no', '-o', 'User=vagrant', '-o', 'ConnectTimeout=10', '192.168.90.103', "/bin/sh -c 'rm -rf /tmp/ansible-tmp-1393931040.65-15247293340451/ >/dev/
null 2>&1'"]
failed: [192.168.90.103] => {"changed": true, "cmd": ["gem", "install", "mailcatcher"], "delta": "0:00:12.608564", "end": "2014-03-04 11:04:13.361538", "item": "", "rc": 1, "start": "20
14-03-04 11:04:00.752974"}
stderr: ERROR:  Error installing mailcatcher:
        ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
        from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from extconf.rb:2:in `<main>'


Gem files will remain installed in /var/lib/gems/1.9.1/gems/eventmachine-1.0.3 for inspection.
Results logged to /var/lib/gems/1.9.1/gems/eventmachine-1.0.3/ext/gem_make.out
stdout: Building native extensions.  This could take a while...

FATAL: all hosts have already failed -- aborting
```

The gem (or one of its dependencies) depends on a native extension that at some point requires MakeMakefile (mkmf).

On Ubuntu the `ruby-dev` package includes all these libraries.
