### PR TITLE
Added in required build files for mailcatcher

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Install required software
   apt: pkg={{ item }} state=latest
   with_items:
+      - build-essential
       - sqlite3
       - libsqlite3-dev
       - ruby-dev


### PR DESCRIPTION
Without `build-essential`, the gem won't install.

Thanks for the role, it's been a great help.  This one tweak is needed so things work if you haven't installed `build-essential` previously.
