### PR TITLE
Failed install on Ubuntu 14.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,11 @@
       - sqlite3
       - libsqlite3-dev
       - ruby-dev
-      - rubygems
-      
+
+- name: Install rubygems
+  apt: pkg=rubygems state=latest
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release > 'trusty'
+
 - name: Install Mailcatcher
   command: gem install mailcatcher
 


### PR DESCRIPTION
Installing on Ubuntu 14.04 fails since Rubygems is not available. Per [launchpad.net](https://launchpad.net/ubuntu/trusty/i386/rubygems/1.8.24-1ubuntu2) Rubygems is already included in Ruby.

I'm new with ansible so if there is a better way please let me know.

I've tested on fresh installs of Ubuntu 12.04 and 14.04.
