### PR TITLE
Set versions and add dependecy to fix mime-type and conversion issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Mailcatcher
-Ansible role for setting up [Mailcatcher](http://mailcatcher.me)
+
+Ansible role for setting up a working [Mailcatcher](http://mailcatcher.me)
+
+* Added a dependency for `mime-types`
+* Specified the version of mailcatcher as `0.5.12` as this is the persistent working version that doesn't break
 
 ## Requirements
 No external requirements exist to this role.
@@ -19,5 +23,6 @@ BSD
 
 ## Author Information
 Stephan Hochhaus [stephan@yauh.de](mailto:stephan@yauh.de)
+_with some changes_
 
 [yauh.de](http://yauh.de)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: "Stephan Hochhaus"
-  description: Set up Mailcatcher
+  description: Set up a working Mailcatcher
   company: Freelance
   license: BSD
   min_ansible_version: 1.4
@@ -11,5 +11,8 @@ galaxy_info:
         - saucy
         - precise
         - trusty
-  categories:
+  galaxy_tags:
    - development
+   - email
+  issue_tracker_url: https://github.com/surfer190/ansible-role-mailcatcher/issues
+  dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,4 @@ galaxy_info:
    - development
    - email
   issue_tracker_url: https://github.com/surfer190/ansible-role-mailcatcher/issues
-  dependencies: []
+dependencies: []

--- a/tasks/install_mailcatcher.yml
+++ b/tasks/install_mailcatcher.yml
@@ -12,8 +12,11 @@
     path=/usr/local/bin/mailcatcher
   register: mailcatcher_installed
 
+- name: Install required mime-types
+  command: gem install mime-types --version "< 3"
+
 - name: Install Mailcatcher
-  command: gem install mailcatcher:0.5.12
+  command: gem install mailcatcher -v 0.5.12
   when: not mailcatcher_installed.stat.exists
 
 - name: Create upstart script for mailcatcher

--- a/tasks/install_mailcatcher.yml
+++ b/tasks/install_mailcatcher.yml
@@ -13,7 +13,7 @@
   register: mailcatcher_installed
 
 - name: Install Mailcatcher
-  command: gem install mailcatcher
+  command: gem install mailcatcher:0.5.12
   when: not mailcatcher_installed.stat.exists
 
 - name: Create upstart script for mailcatcher


### PR DESCRIPTION
Adds requirements to fix:

[Mime-types issue](https://github.com/sj26/mailcatcher/issues/277)
[Encoding issue - Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8](https://github.com/basho/riak-ruby-client/issues/75)
